### PR TITLE
add readme.txt to avoid error when create a locally-editable pgzero 

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,4 @@
+add this file to avoid FileNotFoundError: [Errno 2] No such file or directory: 'D:\\coding\\pgzero\\README.txt' when create a locally-editable install use pip3.
+pip3 install --editable .
+
+maybe the default version of pgzero installed by pip is lower so when debug pgzero code,will not find pgzrun moduel.


### PR DESCRIPTION
add this file to avoid FileNotFoundError: [Errno 2] No such file or directory: 'D:\\coding\\pgzero\\README.txt' when create a locally-editable install use pip3.



```D:\coding\pgzero>pip3 install --editable .
Obtaining file:///D:/coding/pgzero
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "D:\coding\pgzero\setup.py", line 7, in <module>
        with open(path, encoding='utf8') as f:
    FileNotFoundError: [Errno 2] No such file or directory: 'D:\\coding\\pgzero\\README.txt'

```
Command "python setup.py egg_info" failed with error code 1 in D:\coding\pgzero\`
pip3 install --editable .

i realllllly like your work and i have contribute docs to mu editor project and i hope i can get involved in this project!
