### PR TITLE
Added support for flipping Actor images horizontally and vertically.

### DIFF
--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -526,6 +526,29 @@ be floats or the strings ``left``, ``center``/``middle``, ``right``, ``top`` or
 ``bottom`` as appropriate.
 
 
+.. _flipping:
+
+Flipping
+''''''''
+
+Actors can be flipped, so that their image is mirrored horizontally or
+vertically (or both). You can use this to save creating and loading a 
+separate set of images if you want an Actor to move in both directions.
+
+To flip an Actor horizontally, just set its ``flip`` property to ``True``.
+Since our alien faces right, the following will make it face left::
+
+    alien = Actor('alien')
+    alien.flip = True
+
+If you want the alien to flip vertically too (maybe it can walk on the 
+ceiling?), pass it a tuple ``(horizontal, vertical)`` with the vertical value
+set to True::
+
+    alien.flip = (True, True)
+    alien.flip = (False, True)
+
+
 .. _rotation:
 
 Rotation

--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -77,7 +77,8 @@ class Actor:
 
     _anchor = _anchor_value = (0, 0)
     _angle = 0.0
-
+    _flip = (False, False)
+    
     def __init__(self, image, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER, **kwargs):
         self._handle_unexpected_kwargs(kwargs)
 
@@ -127,7 +128,9 @@ class Actor:
         if anchor is None:
             anchor = ("center", "center")
         self.anchor = anchor
-
+        
+        self.flip = (False, False)
+        
         symbolic_pos_args = {
             k: kwargs[k] for k in kwargs if k in SYMBOLIC_POSITIONS}
 
@@ -184,7 +187,15 @@ class Actor:
         ax, ay = self._untransformed_anchor
         self._anchor = transform_anchor(ax, ay, w, h, angle)
         self.pos = p
+    
+    @property
+    def flip(self):
+        return self._flip
 
+    @flip.setter
+    def flip(self, horizontal, vertical=False):
+        self._flip = (bool(horizontal), bool(vertical))
+        
     @property
     def pos(self):
         px, py = self.topleft
@@ -232,7 +243,12 @@ class Actor:
         self.pos = p
 
     def draw(self):
-        game.screen.blit(self._surf, self.topleft)
+        if self._flip == (False, False):
+            game.screen.blit(self._surf, self.topleft)
+        else:
+            flipped = pygame.transform.flip(self._surf, *self.flip)
+            game.screen.blit(flipped, self.topleft)
+
 
     def angle_to(self, target):
         """Return the angle from this actors position to target, in degrees."""


### PR DESCRIPTION
This is a (hopefully) straightforward change which exposes Pygame's ``transform.flip`` in an easy to use way.

- set Actor.flip to True/False to flip horizontally
- set Actor.flip to a ``(horizontal, vertical)`` tuple to set both axes

This seemed cleaner to use than having separate properties for each axis, eg. ``actor.flip_horizontal`` and ``actor.flip_vertical``