### PR TITLE
(Issue #119) Remove return value from reinit screen

### DIFF
--- a/examples/asteroids/main.py
+++ b/examples/asteroids/main.py
@@ -3,6 +3,7 @@ import json
 import operator
 
 from pygame.math import Vector2
+from pgzero.builtins import pause, is_paused
 
 from space import create_star_scape
 from actors import Player, Asteroid
@@ -139,9 +140,11 @@ def on_key_down(key):
             game.player.turn += 1
         if key == keys.RIGHT:
             game.player.turn -= 1
-        if key == keys.SPACE and not game.player.frozen:
+        if key == keys.SPACE and not game.player.frozen and not is_paused():
             sounds.fire.play()
             game.bullets.append(game.player.fire())
+        if key == keys.RETURN:
+            pause()
     elif game.stage is GameStage.game_over:
         if key == keys.BACKSPACE:
             game.initials = game.initials[:-1]

--- a/examples/asteroids/main.py
+++ b/examples/asteroids/main.py
@@ -3,7 +3,6 @@ import json
 import operator
 
 from pygame.math import Vector2
-from pgzero.builtins import pause, is_paused
 
 from space import create_star_scape
 from actors import Player, Asteroid

--- a/pgzero/builtins.py
+++ b/pgzero/builtins.py
@@ -11,4 +11,4 @@ from .loaders import images, sounds
 
 from .constants import mouse, keys, keymods
 
-from .game import exit
+from .game import exit, pause, is_paused

--- a/pgzero/game.py
+++ b/pgzero/game.py
@@ -63,7 +63,6 @@ class PGZeroGame:
 
         """
         global screen
-        changed = False
         mod = self.mod
 
         icon = getattr(self.mod, 'ICON', DEFAULTICON)
@@ -91,8 +90,6 @@ class PGZeroGame:
         if title != self.title:
             pygame.display.set_caption(title)
             self.title = title
-
-        return changed
 
     @staticmethod
     def show_default_icon():
@@ -280,7 +277,7 @@ class PGZeroGame:
                     update(dt)
 
 
-            screen_change = self.reinit_screen()
+            self.reinit_screen()
             if pgzclock.fired or self.need_redraw:
                 draw()
                 pygame.display.flip()

--- a/pgzero/game.py
+++ b/pgzero/game.py
@@ -77,6 +77,7 @@ class PGZeroGame:
         w = getattr(mod, 'WIDTH', 800)
         h = getattr(mod, 'HEIGHT', 600)
         if w != self.width or h != self.height:
+            self.need_redraw = True
             self.screen = pygame.display.set_mode((w, h), DISPLAY_FLAGS)
             if hasattr(self.mod, 'screen'):
                 self.mod.screen.surface = self.screen
@@ -199,9 +200,13 @@ class PGZeroGame:
         except AttributeError:
             return None
         else:
-            if update.__code__.co_argcount == 0:
-                return lambda dt: update()
-            return update
+            def update_wrapper(dt):
+                if update.__code__.co_argcount == 0:
+                    update()
+                else:
+                    update(dt)
+                self.need_redraw = True
+            return update_wrapper
 
     def get_draw_func(self):
         """Get a draw function.
@@ -250,7 +255,7 @@ class PGZeroGame:
 
         pgzclock = pgzero.clock.clock
 
-        self.need_redraw = not paused
+        self.need_redraw = True
         while True:
             # TODO: Use asyncio.sleep() for frame delay if accurate enough
             yield from asyncio.sleep(0)
@@ -268,13 +273,15 @@ class PGZeroGame:
                     self.keyboard._release(event.key)
                 self.dispatch_event(event)
 
-
-            if update and not paused:
+            if not paused:
                 pgzclock.tick(dt)
-                update(dt)
+
+                if update:
+                    update(dt)
+
 
             screen_change = self.reinit_screen()
-            if screen_change or update or pgzclock.fired or self.need_redraw:
+            if pgzclock.fired or self.need_redraw:
                 draw()
                 pygame.display.flip()
                 self.need_redraw = False

--- a/pgzero/game.py
+++ b/pgzero/game.py
@@ -13,7 +13,14 @@ from . import constants
 
 screen = None
 DISPLAY_FLAGS = 0
+paused = False
 
+def pause():
+    global paused
+    paused = not paused
+
+def is_paused():
+    return paused
 
 def exit():
     """Wait for up to a second for all sounds to play out
@@ -243,7 +250,7 @@ class PGZeroGame:
 
         pgzclock = pgzero.clock.clock
 
-        self.need_redraw = True
+        self.need_redraw = not paused
         while True:
             # TODO: Use asyncio.sleep() for frame delay if accurate enough
             yield from asyncio.sleep(0)
@@ -261,9 +268,9 @@ class PGZeroGame:
                     self.keyboard._release(event.key)
                 self.dispatch_event(event)
 
-            pgzclock.tick(dt)
 
-            if update:
+            if update and not paused:
+                pgzclock.tick(dt)
                 update(dt)
 
             screen_change = self.reinit_screen()


### PR DESCRIPTION
Related to the following issue: https://github.com/lordmauve/pgzero/pull/123/commits/9afb94d38fe5f83ab8576ffea28a7c17a979762b

Based on the work in the following branch:
https://github.com/lordmauve/pgzero/pull/123
the reinit_screen function actually no longer needs a return value (only the last commit here adds anything) 👍 