### PR TITLE
Add alias for keyboard.enter which can be used instead of keyboard.return - fix #134

### DIFF
--- a/pgzero/keyboard.py
+++ b/pgzero/keyboard.py
@@ -6,7 +6,6 @@ from .constants import keys
 DEPRECATED_KEY_RE = re.compile(r'[A-Z]')
 PREFIX_RE = re.compile(r'^K_(?!\d$)')
 
-
 class Keyboard:
     """The current state of the keyboard.
 
@@ -22,7 +21,10 @@ class Keyboard:
     _pressed = set()
 
     def __getattr__(self, kname):
-        if DEPRECATED_KEY_RE.match(kname):
+        # return is a reserved word, so alias enter to return
+        if kname == 'enter':
+                kname = 'return'
+        elif DEPRECATED_KEY_RE.match(kname):
             warn(
                 "Uppercase keyboard attributes (eg. keyboard.%s) are "
                 "deprecated." % kname,


### PR DESCRIPTION
This allows 'enter' to be used as an alias instead of using keyboard.return. 

This is required due to return being a reserved word as explained in issue #134 