### PR TITLE
Fix Actor's angle setter

### DIFF
--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -218,8 +218,8 @@ class Actor:
     def angle(self, angle):
         self._angle = angle
         w,h = self._orig_surf.get_size()
-        self.width = abs(w * sin(radians(angle))) + abs(h * cos(radians(angle)))
-        self.height = abs(w * cos(radians(angle))) + abs(h * sin(radians(angle)))
+        self.height = abs(w * sin(radians(angle))) + abs(h * cos(radians(angle)))
+        self.width = abs(w * cos(radians(angle))) + abs(h * sin(radians(angle)))
         ax, ay = self._untransformed_anchor
         p = self.pos
         self._anchor = transform_anchor(ax, ay, w, h, angle)


### PR DESCRIPTION
The Actor's angle setter will now set its width/height attributes correctly. This change will result in the ActorTest's test_right_angle test passing.

**System details (used for testing):**
* windows 10
* python: 3.5.0
* pygame: 1.9.4
* pgzero: master branch (6e96571)
* numpy: 1.15.4

Resolves: #158 
