### PR TITLE
Fix Actor's getter and setter for opacity

### DIFF
--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -49,6 +49,7 @@ ANCHOR_CENTER = None
 MIN_OPACITY = 0.0
 MAX_OPACITY = 1.0
 DEFAULT_OPACITY = MAX_OPACITY
+MAX_ALPHA = 255  # Based on pygame's max alpha.
 
 
 def transform_anchor(ax, ay, w, h, angle):
@@ -82,15 +83,20 @@ def _set_angle(actor, current_surface):
         return current_surface
     return pygame.transform.rotate(current_surface, actor._angle)
 
+
 def _set_opacity(actor, current_surface):
-    if actor.opacity == DEFAULT_OPACITY:
-        # No changes required for default opacity.
+    alpha = int(actor.opacity * MAX_ALPHA + 0.5)  # +0.5 for rounding up.
+
+    if alpha == MAX_ALPHA:
+        # No changes required for fully opaque surfaces (corresponds to the
+        # default opacity of the current_surface).
         return current_surface
 
     alpha_img = pygame.Surface(current_surface.get_size(), pygame.SRCALPHA)
-    alpha_img.fill((255, 255, 255, actor.opacity * 255))
+    alpha_img.fill((255, 255, 255, alpha))
     alpha_img.blit(current_surface, (0, 0), special_flags=pygame.BLEND_RGBA_MULT)
     return alpha_img
+
 
 class Actor:
     EXPECTED_INIT_KWARGS = SYMBOLIC_POSITIONS

--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -45,6 +45,11 @@ SYMBOLIC_POSITIONS = set((
 POS_TOPLEFT = None
 ANCHOR_CENTER = None
 
+# Opacity constants.
+MIN_OPACITY = 0.0
+MAX_OPACITY = 1.0
+DEFAULT_OPACITY = MAX_OPACITY
+
 
 def transform_anchor(ax, ay, w, h, angle):
     """Transform anchor based upon a rotation of a surface of size w x h."""
@@ -73,12 +78,17 @@ def transform_anchor(ax, ay, w, h, angle):
 
 def _set_angle(actor, current_surface):
     if actor._angle % 360 == 0:
+        # No changes required for default angle.
         return current_surface
     return pygame.transform.rotate(current_surface, actor._angle)
 
 def _set_opacity(actor, current_surface):
-    alpha_img = pygame.Surface(current_surface.get_rect().size, pygame.SRCALPHA)
-    alpha_img.fill((255, 255, 255, actor._opacity))
+    if actor.opacity == DEFAULT_OPACITY:
+        # No changes required for default opacity.
+        return current_surface
+
+    alpha_img = pygame.Surface(current_surface.get_size(), pygame.SRCALPHA)
+    alpha_img.fill((255, 255, 255, actor.opacity * 255))
     alpha_img.blit(current_surface, (0, 0), special_flags=pygame.BLEND_RGBA_MULT)
     return alpha_img
 
@@ -89,12 +99,12 @@ class Actor:
     function_order = [_set_opacity, _set_angle]
     _anchor = _anchor_value = (0, 0)
     _angle = 0.0
-    _opacity = 255
+    _opacity = DEFAULT_OPACITY
 
     def _build_transformed_surf(self):
         cache_len = len(self._surface_cache)
         if cache_len == 0:
-            last = self._orig_surf 
+            last = self._orig_surf
         else:
             last = self._surface_cache[-1]
         for f in self.function_order[cache_len:]:
@@ -228,11 +238,22 @@ class Actor:
 
     @property
     def opacity(self):
-        return int(self._opacity/255)
+        """Get/set the current opacity value.
+
+        The allowable range for opacity is any number between and including
+        0.0 and 1.0 (i.e. [0.0, 1.0]). Values outside of this will be clamped
+        to the range.
+
+        0.0 makes the image completely transparent (i.e. invisible).
+        1.0 makes the image completely opaque (i.e. fully viewable).
+        Values between 0.0 and 1.0 will give varying levels of transparency.
+        """
+        return self._opacity
 
     @opacity.setter
     def opacity(self, opacity):
-        self._opacity = opacity*255
+        # Clamp the opacity to the allowable range.
+        self._opacity = min(MAX_OPACITY, max(MIN_OPACITY, opacity))
         self._update_transform(_set_opacity)
 
     @property

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -2,7 +2,8 @@ import unittest
 
 import pygame
 
-from pgzero.actor import calculate_anchor, Actor
+from pgzero.actor import (calculate_anchor, Actor, MIN_OPACITY, MAX_OPACITY,
+        DEFAULT_OPACITY)
 from pgzero.loaders import set_root
 
 
@@ -107,6 +108,41 @@ class ActorTest(unittest.TestCase):
         for _ in range(360):
             a.angle += 1.0
         self.assertEqual(a.pos, (100.0, 100.0))
+
+    def test_opacity_default(self):
+        """Ensure opacity is initially set to its default value."""
+        expected_opacity = DEFAULT_OPACITY
+
+        a = Actor('alien')
+
+        self.assertEqual(a.opacity, expected_opacity)
+
+    def test_opacity_value(self):
+        """Ensure opacity gives the value it was set to."""
+        a = Actor('alien')
+        expected_opacity = 0.54321
+
+        a.opacity = expected_opacity
+
+        self.assertEqual(a.opacity, expected_opacity)
+
+    def test_opacity_min_boundry(self):
+        """Ensure opacity is not set below minimum allowable level."""
+        a = Actor('alien')
+        expected_opacity = MIN_OPACITY
+
+        a.opacity = MIN_OPACITY - 0.1
+
+        self.assertEqual(a.opacity, expected_opacity)
+
+    def test_opacity_max_boundry(self):
+        """Ensure opacity is not set above maximum allowable level."""
+        a = Actor('alien')
+        expected_opacity = MAX_OPACITY
+
+        a.opacity = MAX_OPACITY + 0.1
+
+        self.assertEqual(a.opacity, expected_opacity)
 
     def test_dir_correct(self):
         """Everything returned by dir should be indexable as an attribute."""


### PR DESCRIPTION
This update fixes several issues with the Actor's getter and setter for its `.opacity` attribute.

Overview of changes contained in this pull request:
- Clamp opacity values to the defined constant range to prevent invalid values from being used.
- Return an opacity value in the same format that was used during setting.
- Prevent extra work from being done in `_set_opacity()` (especially when opacity is set to its default).
- Test cases to test getting/setting Actor's opacity.

System details (used for testing):
- os: windows 10
- python: 3.5.0
- pygame: 1.9.4
- pgzero: master branch at ef963beaa22db89cb011695e96587bb268cbec2a
- numpy: 1.15.4

Resolves #162 and resolves #163.