### PR TITLE
Add rect property to Actor

### DIFF
--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -491,7 +491,8 @@ attribute to some new image name::
 
 Actors have all the same attributes and methods as :ref:`Rect <rect>`,
 including methods like `.colliderect()`__ which can be used to test whether
-two actors have collided.
+two actors have collided. A copy of an actor's :ref:`Rect <rect>` can be
+returned using the ``.rect`` attribute.
 
 .. __: https://www.pygame.org/docs/ref/rect.html#pygame.Rect.colliderect
 

--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -491,8 +491,7 @@ attribute to some new image name::
 
 Actors have all the same attributes and methods as :ref:`Rect <rect>`,
 including methods like `.colliderect()`__ which can be used to test whether
-two actors have collided. A copy of an actor's :ref:`Rect <rect>` can be
-returned using the ``.rect`` attribute.
+two actors have collided.
 
 .. __: https://www.pygame.org/docs/ref/rect.html#pygame.Rect.colliderect
 

--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -292,9 +292,12 @@ class Actor:
         ax, ay = self._anchor
         self.topleft = px - ax, py - ay
 
-    @property
     def rect(self):
-        """Get a copy of the actor's rect object."""
+        """Get a copy of the actor's rect object.
+
+        This allows Actors to duck-type like rects in Pygame rect operations,
+        and is not expected to be used in user code.
+        """
         return self._rect.copy()
 
     @property

--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -293,6 +293,11 @@ class Actor:
         self.topleft = px - ax, py - ay
 
     @property
+    def rect(self):
+        """Get a copy of the actor's rect object."""
+        return self._rect.copy()
+
+    @property
     def x(self):
         ax = self._anchor[0]
         return self.left + ax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-pygame
+pygame>=2.1
 pyfxr>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with io.open(path, encoding='utf8') as f:
     LONG_DESCRIPTION = f.read()
 
 install_requires = [
-    "pygame==2.*",
+    "pygame>=2.1",
     'numpy',
     'pyfxr',
 ]


### PR DESCRIPTION
This update adds a read only `.rect` property to the `Actor` class.

Overview of changes contained in this pull request:
- Add a `.rect` property to the `Actor` class to allow actor objects to be accepted as `Rect` type/style arguments.
- To prevent users from mistakenly making changes to the actor's rect values:
    - The `.rect` property is read only.
    - The `Rect` object returned from `.rect` is a copy of the actor's rect.

Notes:
- The merge of this PR should now allow PR #93 to be merged.
- The following is not directly related to this update, but something that users should be made aware of. The underlying pgzero/pygame code for detecting collisions, when an actor is rotated, will probably not work as the user expects. When an actor's image is rotated, the actor's rect is not rotated; it is expanded to enclose the rotated image. This could cause collisions to be detected when visually there appears to be no collision.

System details:
- os: windows 10
- python: 3.5.0
- pygame: 1.9.4
- pgzero: master branch at ef963beaa22db89cb011695e96587bb268cbec2a
- numpy: 1.15.4

Resolves #94.