### PR TITLE
Clear Actor's image cache when image changed

### DIFF
--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -273,6 +273,7 @@ class Actor:
     def image(self, image):
         self._image_name = image
         self._orig_surf = loaders.images.load(image)
+        self._surface_cache.clear()  # Clear out old image's cache.
         self._update_pos()
 
     def _update_pos(self):


### PR DESCRIPTION
This update clear's an actor's image cache when the image is changed.

Overview of changes contained in this pull request:
- The `Actor`'s `self._surface_cache` contains cached images that need to be cleared when a new `.image` is set.


System details:
- os: windows 10
- python: 3.5.0
- pygame: 1.9.4
- pgzero: master branch at ef963beaa22db89cb011695e96587bb268cbec2a
- numpy: 1.15.4

Resolves #168.