### PR TITLE
Make `screen` global variable usable for other modules

### DIFF
--- a/pgzero/game.py
+++ b/pgzero/game.py
@@ -70,12 +70,13 @@ class PGZeroGame:
         w = getattr(mod, 'WIDTH', 800)
         h = getattr(mod, 'HEIGHT', 600)
         if w != self.width or h != self.height:
-            self.screen = pygame.display.set_mode((w, h), DISPLAY_FLAGS)
+            surface = pygame.display.set_mode((w, h), DISPLAY_FLAGS)
             if hasattr(self.mod, 'screen'):
-                self.mod.screen.surface = self.screen
+                self.mod.screen.surface = surface
             else:
-                self.mod.screen = pgzero.screen.Screen(self.screen)
-            screen = self.screen     # KILL ME
+                self.mod.screen = pgzero.screen.Screen(surface)
+            self.screen = self.mod.screen
+            screen = self.screen
             self.width = w
             self.height = h
 


### PR DESCRIPTION
The global `screen` variable defined in game.py was initialized as a Surface instead of a Screen. Fix this to make it possible to write a module which uses the global `screen` variable like this:

    from pgzero import game

    def draw_ball(x, y):
        game.screen.draw.circle((x, y), 12, (255, 255, 255))

Hopefully this does not break any plan related to the "KILL ME" comment.