### PR TITLE
Fixed bugs in saving with Storage class

### DIFF
--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -56,6 +56,7 @@ class Storage(dict):
     @classmethod
     def save_all(cls):
         """Save all instances of Storage."""
+        cls._ensure_save_path()
         for storage in cls.storages:
             storage.save()
 

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -64,7 +64,7 @@ class Storage(dict):
     def _ensure_save_path(cls):
         """Ensure that the directory for all save game data exists."""
         try:
-            os.makedirs(cls.SOTRAGE_DIR)
+            os.makedirs(cls.STORAGE_DIR)
         except IsADirectoryError:
             pass
         except FileExistsError:

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -63,9 +63,8 @@ class Storage(dict):
     @classmethod
     def _ensure_save_path(cls):
         """Ensure that the directory for all save game data exists."""
-        storage_path = cls._get_platform_pgzero_path()
         try:
-            os.makedirs(storage_path)
+            os.makedirs(cls.SOTRAGE_DIR)
         except IsADirectoryError:
             pass
         except FileExistsError:

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -67,6 +67,8 @@ class Storage(dict):
             os.makedirs(storage_path)
         except IsADirectoryError:
             pass
+        except FileExistsError:
+            pass
 
     def _set_filename_from_path(self, file_path):
         """Set the path to save to from the given filename.


### PR DESCRIPTION
This is a few minor fixes. On my computer, Arch Linux with Python 3.7, `os.makedirs` raises FileExistsError, not IsADirectoryError, so I added a check for that error. `Storage._ensure_save_path` was never actually called in previous code, so I added a call to that in `Storage.save_all`. This will create the directory even if nothing is actually saved, but I don't think that is a significant problem. Third, `_get_platform_pgzero_path` is a module function, not a classmethod, and the result is stored in `Storage.STORAGE_DIR`, so I changed the code to use that variable rather than attempting to call `Storage._get_platform_pgzero_path` which doesn't exist.