### PR TITLE
Updated Asteroids example to use the Storage API

### DIFF
--- a/examples/asteroids/main.py
+++ b/examples/asteroids/main.py
@@ -105,8 +105,7 @@ def update(dt):
             game.stage = GameStage.game_over
 
     if game.stage is GameStage.leader_board and not game.leader_board:
-        with open('leaderboard.json', 'r') as lb:
-            leader_board = json.load(lb) or []
+        leader_board = storage.setdefault("leader_board", [])
         max_leaders = {}
         for initial, score in leader_board:
             max_leaders[initial] = max(score, max_leaders.get(initial, 0))
@@ -147,14 +146,8 @@ def on_key_down(key):
         if key == keys.BACKSPACE:
             game.initials = game.initials[:-1]
         elif key == keys.RETURN and game.initials:
-            try:
-                with open('leaderboard.json', 'r') as lb:
-                    leader_board = json.load(lb)
-            except (ValueError, FileNotFoundError):
-                leader_board = []
+            leader_board = storage.setdefault("leader_board", [])
             leader_board.append((game.initials, game.score))
-            with open('leaderboard.json', 'w') as lb:
-                json.dump(leader_board, lb)
             game.leader_board = {}
             game.stage = GameStage.leader_board
         elif len(game.initials) < 3 and keys.A <= key <= keys.Z:

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -56,6 +56,7 @@ class Storage(dict):
     @classmethod
     def save_all(cls):
         """Save all instances of Storage."""
+        cls._ensure_save_path()
         for storage in cls.storages:
             storage.save()
 

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -64,7 +64,7 @@ class Storage(dict):
     def _ensure_save_path(cls):
         """Ensure that the directory for all save game data exists."""
         try:
-            os.makedirs(cls.SOTRAGE_DIR)
+            os.makedirs(cls.STORAGE_DIR)
         except IsADirectoryError:
             pass
         except FileExistsError:

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -63,9 +63,8 @@ class Storage(dict):
     @classmethod
     def _ensure_save_path(cls):
         """Ensure that the directory for all save game data exists."""
-        storage_path = cls._get_platform_pgzero_path()
         try:
-            os.makedirs(storage_path)
+            os.makedirs(cls.SOTRAGE_DIR)
         except IsADirectoryError:
             pass
         except FileExistsError:

--- a/pgzero/storage.py
+++ b/pgzero/storage.py
@@ -67,6 +67,8 @@ class Storage(dict):
             os.makedirs(storage_path)
         except IsADirectoryError:
             pass
+        except FileExistsError:
+            pass
 
     def _set_filename_from_path(self, file_path):
         """Set the path to save to from the given filename.


### PR DESCRIPTION
Mostly, this involved changing the file loading parts to use `storage.setdefault`. `setdefault` is used instead of `get` because it also adds the key to the dictionary, which I would expect to be used practically always for a save file. I tested this multiple times, including deleting the save file.As far as I can tell, it works.