### PR TITLE
Add move_forwards(dist) for Actor.  Closes #193

### DIFF
--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -331,6 +331,12 @@ class Actor:
         s = self._build_transformed_surf()
         game.screen.blit(s, self.topleft)
 
+    def move_forwards(self, distance):
+        """Move this actor forwards a distance, according to its angle."""
+        angleInRads = radians(self.angle)
+        self.x += cos(angleInRads) * distance
+        self.y += sin(angleInRads) * -distance
+
     def angle_to(self, target):
         """Return the angle from this actors position to target, in degrees."""
         if isinstance(target, Actor):

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -110,6 +110,31 @@ class ActorTest(unittest.TestCase):
             a.angle += 1.0
         self.assertEqual(a.pos, (100.0, 100.0))
 
+    def test_move_forwards_ne(self):
+        """move fwd should change pos correctly when facing roughly NE"""
+        a = Actor('alien', pos=(100.0, 200.0))
+        # the angle for a 3 4 5 triangle
+        a.angle = 53.1301024
+        a.move_forwards(5)
+        self.assertAlmostEqual(a.x, 103)
+        self.assertAlmostEqual(a.y, 196)
+
+    def test_move_forwards_sw(self):
+        """Move fwd should change pos correctly when facing roughly SW"""
+        a = Actor('alien', pos=(100.0, 200.0))
+        a.angle = 180 + 53.1301024
+        a.move_forwards(5)
+        self.assertAlmostEqual(a.x, 97)
+        self.assertAlmostEqual(a.y, 204)
+
+    def test_move_forwards_zero(self):
+        """"""
+        a = Actor('alien', pos=(100.0, 200.0))
+        a.angle = 53.1301024
+        a.move_forwards(0)
+        self.assertEqual(a.x, 100.0)
+        self.assertEqual(a.y, 200.0)
+
     def test_opacity_default(self):
         """Ensure opacity is initially set to its default value."""
         a = Actor('alien')


### PR DESCRIPTION
Adds the ability to say `myActor.move_forwards(10)`.

Hi!  I hope you don't mind me making a PR without first discussing the feature request.  No worries at all if you just close this, but I'd certainly be interested in your thinking on what pygamezero actors should and should not directly provide.