### PR TITLE
Make it possible to inject additional image into image loader cache

### DIFF
--- a/pgzero/loaders.py
+++ b/pgzero/loaders.py
@@ -139,6 +139,10 @@ class ResourceLoader:
         validate_compatible_path(p)
         res = self._cache[key] = self._load(p, *args, **kwargs)
         return res
+    
+    def add(self, name, resource):
+        key = self.cache_key(name, (), {})
+        self.cache[key] = resource
 
     def unload(self, name, *args, **kwargs):
         key = self.cache_key(name, args, kwargs)

--- a/pgzero/loaders.py
+++ b/pgzero/loaders.py
@@ -142,7 +142,7 @@ class ResourceLoader:
     
     def add(self, name, resource):
         key = self.cache_key(name, (), {})
-        self.cache[key] = resource
+        self._cache[key] = resource
 
     def unload(self, name, *args, **kwargs):
         key = self.cache_key(name, args, kwargs)


### PR DESCRIPTION
I have images `dirt.png` and `bush.png` and with this I can create temporary image on the fly when starting the game (so my actor do not need to draw two overlapping images when running the game):

```
import pygame.image
img_dirt = pygame.image.load('images/dirt.png').convert_alpha()
img_bush = pygame.image.load('images/bush_small.png').convert_alpha()
img_dirt.blit(img_bush, (0,0))
images.add('tmp_dirt_with_bush', img_dirt)
my_actor.image = 'tmp_dirt_with_bush'
```

Please let me know if it makes sense.