### PR TITLE
Add tutorials page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,6 +44,7 @@ User Guide
     repl
     ide-mode
     examples
+    tutorials
     other-libs
     changelog
 

--- a/doc/tutorials.rst
+++ b/doc/tutorials.rst
@@ -1,0 +1,11 @@
+Tutorials
+=========
+
+Here are some tutorials and learning resources which use Pygame Zero.
+
+Simple Game Tutorials
+---------------------
+
+`Simple Game Tutorials`_ is a collection of step-by-step tutorials which guide you through the process of making some simple games.
+
+.. _`Simple Game Tutorials`: https://simplegametutorials.github.io/


### PR DESCRIPTION
I've created the start of a tutorials page. I tried to model the structure from the "Other libraries like Pygame Zero" page.

I know that the title "Tutorials" will probably be a misnomer for some learning resources, but I figured it was an understandable and highly searched word.