### PR TITLE
Allow pygame2 on current version of PGZero

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path, encoding='utf8') as f:
     LONG_DESCRIPTION = f.read()
 
 install_requires = [
-    'pygame>=1.9.2, <2.0',
+    'pygame>=1.9.2',
     'numpy',
 ]
 

--- a/test/test_screen.py
+++ b/test/test_screen.py
@@ -1,6 +1,7 @@
 import unittest
 import pygame
 import pygame.image
+import numpy as np
 
 from pgzero.screen import Screen
 from pgzero.loaders import set_root, images
@@ -11,28 +12,54 @@ surf = pygame.display.set_mode((200, 100))
 
 class ScreenTest(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
+        """Initialise the display and set loaders to target the current dir."""
+        pygame.init()
+        cls.surf = pygame.display.set_mode((200, 100))
         set_root(__file__)
 
+    @classmethod
+    def tearDownClass(cls):
+        """Shut down the display."""
+        pygame.display.quit()
+
     def setUp(self):
-        surf.fill((0, 0, 0))
-        self.screen = Screen(surf)
+        self.screen = Screen(self.surf)
+        self.screen.clear()
 
-    def assertImagesEqual(self, a, b):
-        adata, bdata = (pygame.image.tostring(i, 'RGB') for i in (a, b))
+    def assertImagesAlmostEqual(self, computed, expected):
+        """Check that 2 images are approximately equal."""
+        comp_surf = pygame.surfarray.array3d(computed)
+        exp_surf = pygame.surfarray.array3d(expected)
 
-        if adata != bdata:
-            raise AssertionError("Images differ")
+        if np.allclose(comp_surf, exp_surf, atol=2):
+            return
+
+        name = sys._getframe(1).f_code.co_name
+        tmpdir = Path(__file__).parent / 'failed-image'
+        tmpdir.mkdir(exist_ok=True)
+        pygame.image.save(
+            computed,
+            str(tmpdir / '{}-computed.png'.format(name))
+        )
+        pygame.image.save(
+            expected,
+            str(tmpdir / '{}-expected.png'.format(name))
+        )
+
+        raise AssertionError(
+            "Images differ; saved comparison images to {}".format(tmpdir)
+        )
 
     def test_blit_surf(self):
         """We can blit a surface to the screen."""
         self.screen.blit(images.alien, (0, 0))
-        self.assertImagesEqual(surf, images.expected_alien_blit)
+        self.assertImagesAlmostEqual(surf, images.expected_alien_blit)
 
     def test_blit_name(self):
         """screen.blit() accepts an image name instead of a Surface."""
         self.screen.blit('alien', (0, 0))
-        self.assertImagesEqual(surf, images.expected_alien_blit)
+        self.assertImagesAlmostEqual(surf, images.expected_alien_blit)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This branch is intended to allow the current release of PGZero to work with the newly release PyGame2+.

It does this in three ways:

* Modifying the `install_requires` specification for `pygame` to include whatever is the latest version (N.B. you may want to specify this in a less open ended manner).
* Backport a couple of useful test-related functions for testing `Screen` related functionality.
* Revise the existing tests for 1.2 `Screen` tests to use the backported functions mentioned above.

Happy to change anything you may need (see note on pinning `pygame` version).

Finally, thanks as always for all the work that continues to happen on PGZero. 