### PR TITLE
Fix pgzero/game.py:5:1: F401 'builtins' imported but unused

### DIFF
--- a/pgzero/game.py
+++ b/pgzero/game.py
@@ -2,7 +2,6 @@ import sys
 import operator
 import time
 import asyncio
-import builtins
 
 import pygame
 import pgzero.clock


### PR DESCRIPTION
Fix GitHub Actions which are now failing because of changes made in https://github.com/lordmauve/pgzero/commit/9fe032577c93fd89be2b844be45d951bbabb08dd