### PR TITLE
Merge with pgzhelper: add scale, flip_x, flip_y properties, to Actor...

### DIFF
--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -255,7 +255,8 @@ class Actor:
         ay = calculate_anchor(ay, 'y', oh)
         self._untransformed_anchor = ax, ay
         if self._angle == 0.0:
-            self._anchor = self._untransformed_anchor
+            anchor = self._untransformed_anchor
+            self._anchor = (anchor[0] * self._scale, anchor[1] * self._scale)
         else:
             self._anchor = transform_anchor(ax, ay, ow, oh, self._angle, self._scale)
 

--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -48,7 +48,7 @@ ANCHOR_CENTER = None
 MAX_ALPHA = 255  # Based on pygame's max alpha.
 
 
-def transform_anchor(ax, ay, w, h, angle):
+def transform_anchor(ax, ay, w, h, angle, scale=1.0):
     """Transform anchor based upon a rotation of a surface of size w x h."""
     theta = -radians(angle)
 
@@ -68,8 +68,8 @@ def transform_anchor(ax, ay, w, h, angle):
     ray = cax * sintheta + cay * costheta
 
     return (
-        tw * 0.5 + rax,
-        th * 0.5 + ray
+        (tw * 0.5 + rax)*scale,
+        (th * 0.5 + ray)*scale
     )
 
 
@@ -78,6 +78,22 @@ def _set_angle(actor, current_surface):
         # No changes required for default angle.
         return current_surface
     return pygame.transform.rotate(current_surface, actor._angle)
+
+
+def _set_scale(actor, current_surface):
+    if actor._scale == 1.0:
+        # No changes required for default scale.
+        return current_surface
+    new_width = int(current_surface.get_width() * actor._scale)
+    new_height = int(current_surface.get_height() * actor._scale)
+    return pygame.transform.scale(current_surface, (new_width, new_height))
+
+
+def _set_flip(actor, current_surface):
+    if (not actor._flip_x) and (not actor._flip_y):
+        # No changes required for default flip.
+        return current_surface
+    return pygame.transform.flip(current_surface, actor._flip_x, actor._flip_y)
 
 
 def _set_opacity(actor, current_surface):
@@ -104,8 +120,11 @@ class Actor:
         a for a in dir(rect.ZRect) if not a.startswith("_")
     ]
 
-    function_order = [_set_opacity, _set_angle]
+    function_order = [_set_opacity, _set_scale, _set_flip, _set_angle]
     _anchor = _anchor_value = (0, 0)
+    _scale = 1.0
+    _flip_x = False
+    _flip_y = False
     _angle = 0.0
     _opacity = 1.0
 
@@ -238,7 +257,20 @@ class Actor:
         if self._angle == 0.0:
             self._anchor = self._untransformed_anchor
         else:
-            self._anchor = transform_anchor(ax, ay, ow, oh, self._angle)
+            self._anchor = transform_anchor(ax, ay, ow, oh, self._angle, self._scale)
+
+    def _transform(self):
+        w, h = self._orig_surf.get_size()
+
+        ra = radians(self._angle)
+        sin_a = sin(ra)
+        cos_a = cos(ra)
+        self.height = int((abs(w * sin_a) + abs(h * cos_a))*self._scale)
+        self.width = int((abs(w * cos_a) + abs(h * sin_a))*self._scale)
+        ax, ay = self._untransformed_anchor
+        p = self.pos
+        self._anchor = transform_anchor(ax, ay, w, h, self._angle, self._scale)
+        self.pos = p
 
     @property
     def angle(self):
@@ -246,19 +278,41 @@ class Actor:
 
     @angle.setter
     def angle(self, angle):
-        self._angle = angle
-        w, h = self._orig_surf.get_size()
+        if self._angle != angle:
+            self._angle = angle
+            self._transform()
+            self._update_transform(_set_angle)
 
-        ra = radians(angle)
-        sin_a = sin(ra)
-        cos_a = cos(ra)
-        self.height = abs(w * sin_a) + abs(h * cos_a)
-        self.width = abs(w * cos_a) + abs(h * sin_a)
-        ax, ay = self._untransformed_anchor
-        p = self.pos
-        self._anchor = transform_anchor(ax, ay, w, h, angle)
-        self.pos = p
-        self._update_transform(_set_angle)
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, scale):
+        if self._scale != scale:
+            self._scale = scale
+            self._transform()
+            self._update_transform(_set_scale)
+
+    @property
+    def flip_x(self):
+        return self._flip_x
+
+    @flip_x.setter
+    def flip_x(self, flip_x):
+        if self._flip_x != flip_x:
+            self._flip_x = flip_x
+            self._update_transform(_set_flip)
+
+    @property
+    def flip_y(self):
+        return self._flip_y
+
+    @flip_y.setter
+    def flip_y(self, flip_y):
+        if self._flip_y != flip_y:
+            self._flip_y = flip_y
+            self._update_transform(_set_flip)
 
     @property
     def opacity(self):
@@ -277,8 +331,10 @@ class Actor:
     @opacity.setter
     def opacity(self, opacity):
         # Clamp the opacity to the allowable range.
-        self._opacity = min(1.0, max(0.0, opacity))
-        self._update_transform(_set_opacity)
+        new_opacity = min(1.0, max(0.0, opacity))
+        if self._opacity != new_opacity:
+            self._opacity = new_opacity
+            self._update_transform(_set_opacity)
 
     @property
     def pos(self):

--- a/pgzero/actor.py
+++ b/pgzero/actor.py
@@ -84,8 +84,8 @@ def _set_scale(actor, current_surface):
     if actor._scale == 1.0:
         # No changes required for default scale.
         return current_surface
-    new_width = int(current_surface.get_width() * actor._scale)
-    new_height = int(current_surface.get_height() * actor._scale)
+    new_width = current_surface.get_width() * actor._scale
+    new_height = current_surface.get_height() * actor._scale
     return pygame.transform.scale(current_surface, (new_width, new_height))
 
 
@@ -265,8 +265,8 @@ class Actor:
         ra = radians(self._angle)
         sin_a = sin(ra)
         cos_a = cos(ra)
-        self.height = int((abs(w * sin_a) + abs(h * cos_a))*self._scale)
-        self.width = int((abs(w * cos_a) + abs(h * sin_a))*self._scale)
+        self.height = (abs(w * sin_a) + abs(h * cos_a))*self._scale
+        self.width = (abs(w * cos_a) + abs(h * sin_a))*self._scale
         ax, ay = self._untransformed_anchor
         p = self.pos
         self._anchor = transform_anchor(ax, ay, w, h, self._angle, self._scale)

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -110,6 +110,27 @@ class ActorTest(unittest.TestCase):
             a.angle += 1.0
         self.assertEqual(a.pos, (100.0, 100.0))
 
+    def test_no_scaling(self):
+        a = Actor('alien', pos=(100.0, 100.0))
+        originial_size = (a.width, a.height)
+
+        a.scale = 1
+        self.assertEqual((a.width, a.height) + a.pos, originial_size + a.pos)
+
+    def test_scale_down(self):
+        a = Actor('alien', pos=(100.0, 100.0))
+        scale = 0.25
+        exp_size = (int(a.width*scale), int(a.height*scale))
+        a.scale = scale
+        self.assertEqual((a.width, a.height) + a.pos, exp_size + (100.0, 100.0))
+
+    def test_scale_up(self):
+        a = Actor('alien', pos=(100.0, 100.0))
+        scale = 2.5
+        exp_size = (int(a.width*scale), int(a.height*scale))
+        a.scale = scale
+        self.assertEqual((a.width, a.height) + a.pos, exp_size + (100.0, 100.0))
+
     def test_opacity_default(self):
         """Ensure opacity is initially set to its default value."""
         a = Actor('alien')

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -120,14 +120,14 @@ class ActorTest(unittest.TestCase):
     def test_scale_down(self):
         a = Actor('alien', pos=(100.0, 100.0))
         scale = 0.25
-        exp_size = (int(a.width*scale), int(a.height*scale))
+        exp_size = (a.width*scale, a.height*scale)
         a.scale = scale
         self.assertEqual((a.width, a.height) + a.pos, exp_size + (100.0, 100.0))
 
     def test_scale_up(self):
         a = Actor('alien', pos=(100.0, 100.0))
         scale = 2.5
-        exp_size = (int(a.width*scale), int(a.height*scale))
+        exp_size = (a.width*scale, a.height*scale)
         a.scale = scale
         self.assertEqual((a.width, a.height) + a.pos, exp_size + (100.0, 100.0))
 


### PR DESCRIPTION
add scale, flip_x, flip_y properties to Actor
the change in code is based on [pgzhelper](https://github.com/QuirkyCort/pgzhelper)
what it does:

scales the anchor point without moving the actor
updates width/height
slots into the transform stack (after opacity, before rotation) so that operations compose correctly