### PR TITLE
Reintroduce default display mode (fixes #264)

### DIFF
--- a/pgzero/runner.py
+++ b/pgzero/runner.py
@@ -168,6 +168,9 @@ def prepare_mod(mod):
     storage.storage._set_filename_from_path(mod.__file__)
     loaders.set_root(mod.__file__)
 
+    # The display mode must be set for IDE mode
+    pygame.display.set_mode((100, 100), DISPLAY_FLAGS)
+
     # Copy pgzero builtins into system builtins
     from . import builtins as pgzero_builtins
     import builtins as python_builtins


### PR DESCRIPTION
Commit bf48fc964b5168d8e1e101a32adc2ac6cb685c69 (Destroy temporary window after initial load) introduced a crash in convert_alpha() ("No video mode has been set") when using IDE mode. This commit brings back the original line of code setting the display mode.

The issue also mentions bringing back `PGZeroGame.show_default_icon()`, but I did not see a need for it.