### PR TITLE
Fix GHA workflow badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-.. image:: https://img.shields.io/github/workflow/status/lordmauve/pgzero/Run%20tests/master
+.. image:: https://img.shields.io/github/actions/workflow/status/lordmauve/pgzero/test.yml?branch=main
     :target: https://github.com/lordmauve/pgzero/actions/workflows/test.yml
     :alt: GitHub Test Status
 


### PR DESCRIPTION
Shields changed the URL path of their badges. See https://github.com/badges/shields/issues/8671 for details.

As an alternative you could use GHA's badge URLs directly, e.g. https://github.com/lordmauve/pgzero/actions/workflows/test.yml/badge.svg