### PR TITLE
Update GitHub Action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -32,7 +32,7 @@ jobs:
         xvfb-run --auto-servernum pytest
     - name: Cleanup xvfb pidx
       uses: bcomnes/cleanup-xvfb@v1
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:
           name: failed-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Install xvfb and pulseaudio
+      run: |
+          sudo apt update
+          sudo apt install -y xvfb pulseaudio
     - uses: actions/checkout@v4
     - name: Set up Python 3.x
       uses: actions/setup-python@v5
@@ -21,10 +25,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # stricter tests for mission critical code
         flake8 --count src test
-
-    - name: Install xvfb and pulseaudio
-      run: |
-          sudo apt-get install xvfb pulseaudio
     - name: Run tests under xvfb
       run: |
         export XDG_RUNTIME_DIR="$RUNNER_TEMP"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,20 +1,20 @@
 name: "Build Wheels"
 
 on:
-  workflow_dispatch:
   push:
-  release:
-    types:
-    - published
+    branches:
+    - main
+    tags:
+    - 'v*.*.*'
 
 jobs:
   buildpackage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: Install wheel and SDist requirements
       run: python -m pip install "setuptools>=42.0" wheel twine
@@ -22,7 +22,7 @@ jobs:
     - name: Build SDist
       run: python setup.py sdist bdist_wheel
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         path: |
             dist/*.tar.gz
@@ -33,13 +33,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
+    permissions:
+      id-token: write
+
+    environment: release
+
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist
 
-    - uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_password }}
+    - uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
Various actions breaking due to out of date version numbers. Update all to latest. Also enable trusted publishing for wheels.yml