### PR TITLE
Add --version argument to pgzrun

### DIFF
--- a/src/pgzero/runner.py
+++ b/src/pgzero/runner.py
@@ -1,6 +1,7 @@
 from . import storage
 from . import clock
 from . import loaders
+from . import __version__
 from .game import PGZeroGame, DISPLAY_FLAGS
 from types import ModuleType
 from argparse import ArgumentParser
@@ -67,6 +68,11 @@ def main():
         '--fps',
         action='store_true',
         help="Print periodic FPS measurements on the terminal."
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {__version__}'
     )
     parser.add_argument(
         'game',


### PR DESCRIPTION
While developing on this project locally I wanted to check what version of pgzrun I was using. That wasn't implemented so I added it to the pgzrun runner.

It looks like this now:
```
$ pgzrun --version
pygame 2.6.1 (SDL 2.28.4, Python 3.13.2)
Hello from the pygame community. https://www.pygame.org/contribute.html
pgzrun 1.2.post5.dev202+gcd4f6dc.d20250413
```
By default it prints the pygame version and the welcome message, which I think is fine, but I'm also open to having it just print the pgzrun version.

I could have started discussion with an issue but the feature/code is so simple I'd just make a pull request :)
