### PR TITLE
FIX #362 - Make actor width and height read-only

### DIFF
--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -101,7 +101,10 @@ def _set_opacity(actor, current_surface):
 class Actor:
     EXPECTED_INIT_KWARGS = SYMBOLIC_POSITIONS
     DELEGATED_ATTRIBUTES = [
-        a for a in dir(rect.ZRect) if not a.startswith("_")
+        a for a in dir(rect.ZRect) if not a.startswith("_") and
+        # To prevent rect width and height being accessible without those
+        # implicating changes to the actors' image width and height.
+        not a == "width" and not a == "height"
     ]
 
     function_order = [_set_opacity, _set_angle]

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -243,27 +243,23 @@ class Actor:
         else:
             self._anchor = transform_anchor(ax, ay, ow, oh, self._angle)
 
-    # TODO: Currently, there is an issue with __setattr__() being used on all
-    #       assignments. width and height can't be set anymore, but there is
-    #       neither warning nor error when trying to do so, which is not good
-    #       enough.
     @property
     def width(self):
         return self._width
 
     @width.setter
-    def width(self, val):
-        print("WARNING: width of an actor can't be set directly. Change the"
-              " actors image to change its dimensions.")
+    def width(self, _):
+        print("WARNING: The width of an actor can't be set directly. Change "
+              "the actors image to change its dimensions.")
 
     @property
     def height(self):
         return self._height
 
     @height.setter
-    def height(self, val):
-        print("WARNING: height of an actor can't be set directly. Change the"
-              " actors image to change its dimensions.")
+    def height(self, _):
+        print("WARNING: The height of an actor can't be set directly. Change "
+              "the actors image to change its dimensions.")
 
     @property
     def angle(self):

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -240,6 +240,28 @@ class Actor:
         else:
             self._anchor = transform_anchor(ax, ay, ow, oh, self._angle)
 
+    # TODO: Currently, there is an issue with __setattr__() being used on all
+    #       assignments. width and height can't be set anymore, but there is
+    #       neither warning nor error when trying to do so, which is not good
+    #       enough.
+    @property
+    def width(self):
+        return self._width
+
+    @width.setter
+    def width(self, val):
+        print("WARNING: width of an actor can't be set directly. Change the"
+              " actors image to change its dimensions.")
+
+    @property
+    def height(self):
+        return self._height
+
+    @height.setter
+    def height(self, val):
+        print("WARNING: height of an actor can't be set directly. Change the"
+              " actors image to change its dimensions.")
+
     @property
     def angle(self):
         return self._angle
@@ -252,8 +274,8 @@ class Actor:
         ra = radians(angle)
         sin_a = sin(ra)
         cos_a = cos(ra)
-        self.height = abs(w * sin_a) + abs(h * cos_a)
-        self.width = abs(w * cos_a) + abs(h * sin_a)
+        self._height = abs(w * sin_a) + abs(h * cos_a)
+        self._width = abs(w * cos_a) + abs(h * sin_a)
         ax, ay = self._untransformed_anchor
         p = self.pos
         self._anchor = transform_anchor(ax, ay, w, h, angle)
@@ -331,7 +353,7 @@ class Actor:
 
     def _update_pos(self):
         p = self.pos
-        self.width, self.height = self._orig_surf.get_size()
+        self._width, self._height = self._orig_surf.get_size()
         self._calc_anchor()
         self.pos = p
 


### PR DESCRIPTION
Fixes #362.

Makes `width` and `height` properties of class `Actor` to prevent writing values to them, since changing an actors' dimensions is not currently supported. When trying to write to those properties, a warning is printed but no error thrown.

This change required removing `width` and `height` from the list of variable handling that is deferred to `ZRect`, but I could not find any regressions to be caused by this.