### PR TITLE
Add simple shape constructors for actors

### DIFF
--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -659,6 +659,54 @@ of transparency:
     A ghost seen through a window looks slightly different to a window seen
     through a ghost.
 
+Simple shapes
+'''''''''''''
+
+If you don't have images yet, not to worry! You can start by creating actors
+from simple colored shapes like a rectangle or a circle. Instead of calling
+``Actor("image_name")`` you instead call ``Actor.shape(dimensions, color)``.
+
+Here's an example::
+
+    character = Actor.square(100, "red")
+    shot = Actor.ellipse(60, 20, "blue")
+    sword = Actor.triangle(50, 15, "green")
+
+Note that since a square is the same length on all sides, you only provide
+one number for the dimensions. With the others, you have to provide two for
+width and height.
+
+The following shapes can be created this way:
+
+.. method:: Actor.square(side, color)
+
+    Creates an actor with a filled square of the given color as its image.
+
+.. method:: Actor.rectangle(width, height, color)
+
+    Creates an actor as a rectangle. The difference to the square function
+    is that here, the image can have an independent width and height.
+
+.. method:: Actor.circle(diameter, color)
+
+    Creates an actor with a filled circle of the given color as its image.
+    The background of the image is transparent.
+
+.. method:: Actor.ellipse(width, height, color)
+
+    Creates an actor as an elliptical. The difference to the circle function
+    is that here, the image can have an independent width and height.
+
+.. method:: Actor.triangle(width, height, color)
+
+    Creates an actor with a filled triangle of the given color as its image.
+    The triangle points to the right so it always points in the direction of
+    the ``angle`` of the actor.
+
+If you wanted to define other parameters like anchor or position when creating
+the actors, you can still do so just like with a normal Actor construction::
+
+    balloon = Actor.circle(50, "red", (150, 150), anchor=("center", "bottom"))
 
 The Keyboard
 ------------

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -222,7 +222,16 @@ class Actor:
 
     @classmethod
     def _make_shape_image(self, kind, width, height, color):
+        """Creates a new shape image and loads it into resources. If an image
+        of the exact parameters already exists, creation is not repeated."""
+        # Create image name and resource cache key from parameters.
         name = kind + str(width) + "x" + str(height) + "_" + str(color)
+        key = (name, (), ())
+        # Return without costly image creation if image already exists.
+        if key in loaders.images._cache:
+            return name
+        # Creates the image with transparency (for non-rects) and fills them
+        # with the appropriate shape.
         s = pygame.Surface((width, height), pygame.SRCALPHA)
         match kind:
             case "__SHAPE_CIRCLE__":
@@ -236,19 +245,23 @@ class Actor:
                                     ((0, 0), (width, height / 2), (0, height)))
             case _:
                 s.fill(color)
-        key = (name, (), ())
+        # Saves the created image in the resource cache for use. This ensures
+        # smooth interoperability with the normal Actor construction.
         loaders.images._cache[key] = s
+        # Returns the name for use in the Actor construction.
         return name
 
     @classmethod
     def square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
                **kwargs):
+        """Creates an actor with a square as an image."""
         name = self._make_shape_image("__SHAPE_SQUARE__", side, side, color)
         return Actor(name, pos, anchor, **kwargs)
 
     @classmethod
     def rectangle(self, width, height, color, pos=POS_TOPLEFT,
                   anchor=ANCHOR_CENTER, **kwargs):
+        """Creates an actor with a rectangle as an image."""
         name = self._make_shape_image("__SHAPE_RECTANGLE__", width, height,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
@@ -256,6 +269,7 @@ class Actor:
     @classmethod
     def circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
                **kwargs):
+        """Creates an actor with a circle as an image."""
         name = self._make_shape_image("__SHAPE_CIRCLE__", diameter, diameter,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
@@ -263,6 +277,7 @@ class Actor:
     @classmethod
     def ellipse(self, width, height, color, pos=POS_TOPLEFT,
                 anchor=ANCHOR_CENTER, **kwargs):
+        """Creates an actor with an ellipse as an image."""
         name = self._make_shape_image("__SHAPE_ELLIPSE__", width, height,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
@@ -270,7 +285,7 @@ class Actor:
     @classmethod
     def triangle(self, width, height, color, pos=POS_TOPLEFT,
                  anchor=ANCHOR_CENTER, **kwargs):
-        name = "__SHAPE_TRIANGLE__"
+        """Creates an actor with a triangle as an image."""
         name = self._make_shape_image("__SHAPE_TRIANGLE__", width, height,
                                       color)
         return Actor(name, pos, anchor, **kwargs)

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -220,6 +220,61 @@ class Actor:
                 "function {!r} does not have a registered order."
                 "".format(function))
 
+    @classmethod
+    def _make_shape_image(self, kind, width, height, color):
+        name = kind + str(width) + "x" + str(height) + "_" + str(color)
+        s = pygame.Surface((width, height), pygame.SRCALPHA)
+        match kind:
+            case "__SHAPE_CIRCLE__":
+                pygame.draw.circle(s, color, (width / 2, height / 2),
+                                   width / 2)
+            case "__SHAPE_ELLIPSE__":
+                pygame.draw.ellipse(s, color,
+                                    pygame.Rect((0, 0), (width, height)))
+            case "__SHAPE_TRIANGLE__":
+                pygame.draw.polygon(s, color,
+                                    ((0, 0), (width, height / 2), (0, height)))
+            case _:
+                s.fill(color)
+        key = (name, (), ())
+        loaders.images._cache[key] = s
+        return name
+
+    @classmethod
+    def square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
+               **kwargs):
+        name = self._make_shape_image("__SHAPE_SQUARE__", side, side, color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def rectangle(self, width, height, color, pos=POS_TOPLEFT,
+                  anchor=ANCHOR_CENTER, **kwargs):
+        name = self._make_shape_image("__SHAPE_RECTANGLE__", width, height,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
+               **kwargs):
+        name = self._make_shape_image("__SHAPE_CIRCLE__", diameter, diameter,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def ellipse(self, width, height, color, pos=POS_TOPLEFT,
+                anchor=ANCHOR_CENTER, **kwargs):
+        name = self._make_shape_image("__SHAPE_ELLIPSE__", width, height,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def triangle(self, width, height, color, pos=POS_TOPLEFT,
+                 anchor=ANCHOR_CENTER, **kwargs):
+        name = "__SHAPE_TRIANGLE__"
+        name = self._make_shape_image("__SHAPE_TRIANGLE__", width, height,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
     @property
     def anchor(self):
         return self._anchor_value

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -4,6 +4,7 @@ import pygame
 
 from pgzero.actor import calculate_anchor, Actor
 from pgzero.loaders import set_root
+from pgzero.loaders import images
 
 
 TEST_MODULE = "pgzero.actor"
@@ -146,3 +147,78 @@ class ActorTest(unittest.TestCase):
         a = Actor("alien")
         for attribute in dir(a):
             a.__getattr__(attribute)
+
+    def test_actor_square(self):
+        """The square image is created correctly and the result is a valid
+        actor."""
+        square = Actor.square(10, "red")
+        name = "__SHAPE_SQUARE__10x10_red"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 10)
+        self.assertEqual(height, 10)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (255, 0, 0, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_rectangle(self):
+        """The rectangle image is created correctly and the result is a valid
+        actor."""
+        square = Actor.rectangle(10, 5, "green")
+        name = "__SHAPE_RECTANGLE__10x5_green"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 10)
+        self.assertEqual(height, 5)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (0, 255, 0, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_circle(self):
+        """The circular image is created correctly and the result is a valid
+        actor."""
+        square = Actor.circle(5, "blue")
+        name = "__SHAPE_CIRCLE__5x5_blue"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 5)
+        self.assertEqual(height, 5)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (0, 0, 255, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_ellipse(self):
+        """The elliptical image is created correctly and the result is a valid
+        actor."""
+        square = Actor.ellipse(5, 10, "yellow")
+        name = "__SHAPE_ELLIPSE__5x10_yellow"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 5)
+        self.assertEqual(height, 10)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (255, 255, 0, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_triangle(self):
+        """The triangular image is created correctly and the result is a valid
+        actor."""
+        square = Actor.triangle(15, 15, "fuchsia")
+        name = "__SHAPE_TRIANGLE__15x15_fuchsia"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 15)
+        self.assertEqual(height, 15)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (255, 0, 255, 255)
+        )
+        self.assertEqual(type(square), Actor)


### PR DESCRIPTION
Actors currently require images. When using PGZero in class, I've often provided images for students to use but they still often end up wanting other dimensions, other colors or similar. Using some Rects and some Actors also gets confusing however, since working with them is different enough to create friction.

This PR introduces five constructors for Actors that each generate a suitable image as a basic shape with a given color and then return the Actor constructed with it. This way, new game objects can quickly be introduced, have all features of actors and can be replaced by actual images when ready by changing a single line in the code.

The available shapes are the following: `square(side, color)`, `rectangle(width, height, color)`, `circle(diameter, color)`, `ellipse(width, height, color)`, `triangle(width, height, color)`. Additional parameters for actor construction are passed on and thus function normally. If a simple shape actor is created with the same parameters, no new image is generated. The caching of images remains exactly the same and so no overhead is created.

Example usage:

```python
player = Actor.rectangle(20, 50, "blue", (150, 150)) # Construction with starting position
shot = Actor.square(5, (255, 120, 80), anchor=("center", "bottom"))
```