### PR TITLE
Actors from simple shapes

### DIFF
--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -659,6 +659,54 @@ of transparency:
     A ghost seen through a window looks slightly different to a window seen
     through a ghost.
 
+Simple shapes
+'''''''''''''
+
+If you don't have images yet, not to worry! You can start by creating actors
+from simple colored shapes like a rectangle or a circle. Instead of calling
+``Actor("image_name")`` you instead call ``Actor.shape(dimensions, color)``.
+
+Here's an example::
+
+    character = Actor.square(100, "red")
+    shot = Actor.ellipse(60, 20, "blue")
+    sword = Actor.triangle(50, 15, "green")
+
+Note that since a square is the same length on all sides, you only provide
+one number for the dimensions. With the others, you have to provide two for
+width and height.
+
+The following shapes can be created this way:
+
+.. method:: Actor.square(side, color)
+
+    Creates an actor with a filled square of the given color as its image.
+
+.. method:: Actor.rectangle(width, height, color)
+
+    Creates an actor as a rectangle. The difference to the square function
+    is that here, the image can have an independent width and height.
+
+.. method:: Actor.circle(diameter, color)
+
+    Creates an actor with a filled circle of the given color as its image.
+    The background of the image is transparent.
+
+.. method:: Actor.ellipse(width, height, color)
+
+    Creates an actor as an elliptical. The difference to the circle function
+    is that here, the image can have an independent width and height.
+
+.. method:: Actor.triangle(width, height, color)
+
+    Creates an actor with a filled triangle of the given color as its image.
+    The triangle points to the right so it always points in the direction of
+    the ``angle`` of the actor.
+
+If you wanted to define other parameters like anchor or position when creating
+the actors, you can still do so just like with a normal Actor construction::
+
+    balloon = Actor.circle(50, "red", (150, 150), anchor=("center", "bottom"))
 
 The Keyboard
 ------------

--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -664,13 +664,13 @@ Simple shapes
 
 If you don't have images yet, not to worry! You can start by creating actors
 from simple colored shapes like a rectangle or a circle. Instead of calling
-``Actor("image_name")`` you instead call ``Actor.shape(dimensions, color)``.
+``Actor("image_name")`` you instead call ``Actor.Shape(dimensions, color)``.
 
 Here's an example::
 
-    character = Actor.square(100, "red")
-    shot = Actor.ellipse(60, 20, "blue")
-    sword = Actor.triangle(50, 15, "green")
+    character = Actor.Square(100, "red")
+    shot = Actor.Ellipse(60, 20, "blue")
+    sword = Actor.Triangle(50, 15, "green")
 
 Note that since a square is the same length on all sides, you only provide
 one number for the dimensions. With the others, you have to provide two for
@@ -678,26 +678,26 @@ width and height.
 
 The following shapes can be created this way:
 
-.. method:: Actor.square(side, color)
+.. method:: Actor.Square(side, color)
 
     Creates an actor with a filled square of the given color as its image.
 
-.. method:: Actor.rectangle(width, height, color)
+.. method:: Actor.Rectangle(width, height, color)
 
     Creates an actor as a rectangle. The difference to the square function
     is that here, the image can have an independent width and height.
 
-.. method:: Actor.circle(diameter, color)
+.. method:: Actor.Circle(diameter, color)
 
     Creates an actor with a filled circle of the given color as its image.
     The background of the image is transparent.
 
-.. method:: Actor.ellipse(width, height, color)
+.. method:: Actor.Ellipse(width, height, color)
 
     Creates an actor as an elliptical. The difference to the circle function
     is that here, the image can have an independent width and height.
 
-.. method:: Actor.triangle(width, height, color)
+.. method:: Actor.Triangle(width, height, color)
 
     Creates an actor with a filled triangle of the given color as its image.
     The triangle points to the right so it always points in the direction of
@@ -706,7 +706,7 @@ The following shapes can be created this way:
 If you wanted to define other parameters like anchor or position when creating
 the actors, you can still do so just like with a normal Actor construction::
 
-    balloon = Actor.circle(50, "red", (150, 150), anchor=("center", "bottom"))
+    balloon = Actor.Circle(50, "red", (150, 150), anchor=("center", "bottom"))
 
 The Keyboard
 ------------

--- a/doc/builtins.rst
+++ b/doc/builtins.rst
@@ -659,43 +659,36 @@ of transparency:
     A ghost seen through a window looks slightly different to a window seen
     through a ghost.
 
+
+.. _simple-shapes:
+
 Simple shapes
 '''''''''''''
 
 If you don't have images yet, not to worry! You can start by creating actors
 from simple colored shapes like a rectangle or a circle. Instead of calling
-``Actor("image_name")`` you instead call ``Actor.Shape(dimensions, color)``.
+``Actor("image_name")`` you instead call
+``Actor.Shape(width, height, color)``.
 
 Here's an example::
 
-    character = Actor.Square(100, "red")
+    character = Actor.Rectangle(100, 100, "red")
     shot = Actor.Ellipse(60, 20, "blue")
     sword = Actor.Triangle(50, 15, "green")
 
-Note that since a square is the same length on all sides, you only provide
-one number for the dimensions. With the others, you have to provide two for
-width and height.
-
 The following shapes can be created this way:
-
-.. method:: Actor.Square(side, color)
-
-    Creates an actor with a filled square of the given color as its image.
 
 .. method:: Actor.Rectangle(width, height, color)
 
-    Creates an actor as a rectangle. The difference to the square function
-    is that here, the image can have an independent width and height.
-
-.. method:: Actor.Circle(diameter, color)
-
-    Creates an actor with a filled circle of the given color as its image.
-    The background of the image is transparent.
+    Creates an actor with a filled rectangle of the given color as its
+    image. To create a perfect square, simply give the same value for both
+    width and height.
 
 .. method:: Actor.Ellipse(width, height, color)
 
-    Creates an actor as an elliptical. The difference to the circle function
-    is that here, the image can have an independent width and height.
+    Creates an actor with a filled circular shape of the given color as its
+    image. The background of the image is transparent. To create a perfect
+    circle, simply give the same value for both width and height.
 
 .. method:: Actor.Triangle(width, height, color)
 
@@ -706,7 +699,7 @@ The following shapes can be created this way:
 If you wanted to define other parameters like anchor or position when creating
 the actors, you can still do so just like with a normal Actor construction::
 
-    balloon = Actor.Circle(50, "red", (150, 150), anchor=("center", "bottom"))
+    balloon = Actor.Ellipse(50, 50, "red", (150, 150), anchor=("center", "bottom"))
 
 The Keyboard
 ------------

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -222,7 +222,16 @@ class Actor:
 
     @classmethod
     def _make_shape_image(self, kind, width, height, color):
+        """Creates a new shape image and loads it into resources. If an image
+        of the exact parameters already exists, creation is not repeated."""
+        # Create image name and resource cache key from parameters.
         name = kind + str(width) + "x" + str(height) + "_" + str(color)
+        key = (name, (), ())
+        # Return without costly image creation if image already exists.
+        if key in loaders.images._cache:
+            return name
+        # Creates the image with transparency (for non-rects) and fills them
+        # with the appropriate shape.
         s = pygame.Surface((width, height), pygame.SRCALPHA)
         match kind:
             case "__SHAPE_CIRCLE__":
@@ -236,19 +245,23 @@ class Actor:
                                     ((0, 0), (width, height / 2), (0, height)))
             case _:
                 s.fill(color)
-        key = (name, (), ())
+        # Saves the created image in the resource cache for use. This ensures
+        # smooth interoperability with the normal Actor construction.
         loaders.images._cache[key] = s
+        # Returns the name for use in the Actor construction.
         return name
 
     @classmethod
     def square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
                **kwargs):
+        """Creates an actor with a square as an image."""
         name = self._make_shape_image("__SHAPE_SQUARE__", side, side, color)
         return Actor(name, pos, anchor, **kwargs)
 
     @classmethod
     def rectangle(self, width, height, color, pos=POS_TOPLEFT,
                   anchor=ANCHOR_CENTER, **kwargs):
+        """Creates an actor with a rectangle as an image."""
         name = self._make_shape_image("__SHAPE_RECTANGLE__", width, height,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
@@ -256,6 +269,7 @@ class Actor:
     @classmethod
     def circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
                **kwargs):
+        """Creates an actor with a circle as an image."""
         name = self._make_shape_image("__SHAPE_CIRCLE__", diameter, diameter,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
@@ -263,6 +277,7 @@ class Actor:
     @classmethod
     def ellipse(self, width, height, color, pos=POS_TOPLEFT,
                 anchor=ANCHOR_CENTER, **kwargs):
+        """Creates an actor with an ellipse as an image."""
         name = self._make_shape_image("__SHAPE_ELLIPSE__", width, height,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
@@ -270,7 +285,7 @@ class Actor:
     @classmethod
     def triangle(self, width, height, color, pos=POS_TOPLEFT,
                  anchor=ANCHOR_CENTER, **kwargs):
-        name = "__SHAPE_TRIANGLE__"
+        """Creates an actor with a triangle as an image."""
         name = self._make_shape_image("__SHAPE_TRIANGLE__", width, height,
                                       color)
         return Actor(name, pos, anchor, **kwargs)

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -220,6 +220,61 @@ class Actor:
                 "function {!r} does not have a registered order."
                 "".format(function))
 
+    @classmethod
+    def _make_shape_image(self, kind, width, height, color):
+        name = kind + str(width) + "x" + str(height) + "_" + str(color)
+        s = pygame.Surface((width, height), pygame.SRCALPHA)
+        match kind:
+            case "__SHAPE_CIRCLE__":
+                pygame.draw.circle(s, color, (width / 2, height / 2),
+                                   width / 2)
+            case "__SHAPE_ELLIPSE__":
+                pygame.draw.ellipse(s, color,
+                                    pygame.Rect((0, 0), (width, height)))
+            case "__SHAPE_TRIANGLE__":
+                pygame.draw.polygon(s, color,
+                                    ((0, 0), (width, height / 2), (0, height)))
+            case _:
+                s.fill(color)
+        key = (name, (), ())
+        loaders.images._cache[key] = s
+        return name
+
+    @classmethod
+    def square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
+               **kwargs):
+        name = self._make_shape_image("__SHAPE_SQUARE__", side, side, color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def rectangle(self, width, height, color, pos=POS_TOPLEFT,
+                  anchor=ANCHOR_CENTER, **kwargs):
+        name = self._make_shape_image("__SHAPE_RECTANGLE__", width, height,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
+               **kwargs):
+        name = self._make_shape_image("__SHAPE_CIRCLE__", diameter, diameter,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def ellipse(self, width, height, color, pos=POS_TOPLEFT,
+                anchor=ANCHOR_CENTER, **kwargs):
+        name = self._make_shape_image("__SHAPE_ELLIPSE__", width, height,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
+    @classmethod
+    def triangle(self, width, height, color, pos=POS_TOPLEFT,
+                 anchor=ANCHOR_CENTER, **kwargs):
+        name = "__SHAPE_TRIANGLE__"
+        name = self._make_shape_image("__SHAPE_TRIANGLE__", width, height,
+                                      color)
+        return Actor(name, pos, anchor, **kwargs)
+
     @property
     def anchor(self):
         return self._anchor_value

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -234,9 +234,6 @@ class Actor:
         # with the appropriate shape.
         s = pygame.Surface((width, height), pygame.SRCALPHA)
         match kind:
-            case "__SHAPE_CIRCLE__":
-                pygame.draw.circle(s, color, (width / 2, height / 2),
-                                   width / 2)
             case "__SHAPE_ELLIPSE__":
                 pygame.draw.ellipse(s, color,
                                     pygame.Rect((0, 0), (width, height)))
@@ -252,25 +249,10 @@ class Actor:
         return name
 
     @classmethod
-    def Square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
-               **kwargs):
-        """Creates an actor with a square as an image."""
-        name = self._make_shape_image("__SHAPE_SQUARE__", side, side, color)
-        return Actor(name, pos, anchor, **kwargs)
-
-    @classmethod
     def Rectangle(self, width, height, color, pos=POS_TOPLEFT,
                   anchor=ANCHOR_CENTER, **kwargs):
         """Creates an actor with a rectangle as an image."""
         name = self._make_shape_image("__SHAPE_RECTANGLE__", width, height,
-                                      color)
-        return Actor(name, pos, anchor, **kwargs)
-
-    @classmethod
-    def Circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
-               **kwargs):
-        """Creates an actor with a circle as an image."""
-        name = self._make_shape_image("__SHAPE_CIRCLE__", diameter, diameter,
                                       color)
         return Actor(name, pos, anchor, **kwargs)
 

--- a/src/pgzero/actor.py
+++ b/src/pgzero/actor.py
@@ -252,14 +252,14 @@ class Actor:
         return name
 
     @classmethod
-    def square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
+    def Square(self, side, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
                **kwargs):
         """Creates an actor with a square as an image."""
         name = self._make_shape_image("__SHAPE_SQUARE__", side, side, color)
         return Actor(name, pos, anchor, **kwargs)
 
     @classmethod
-    def rectangle(self, width, height, color, pos=POS_TOPLEFT,
+    def Rectangle(self, width, height, color, pos=POS_TOPLEFT,
                   anchor=ANCHOR_CENTER, **kwargs):
         """Creates an actor with a rectangle as an image."""
         name = self._make_shape_image("__SHAPE_RECTANGLE__", width, height,
@@ -267,7 +267,7 @@ class Actor:
         return Actor(name, pos, anchor, **kwargs)
 
     @classmethod
-    def circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
+    def Circle(self, diameter, color, pos=POS_TOPLEFT, anchor=ANCHOR_CENTER,
                **kwargs):
         """Creates an actor with a circle as an image."""
         name = self._make_shape_image("__SHAPE_CIRCLE__", diameter, diameter,
@@ -275,7 +275,7 @@ class Actor:
         return Actor(name, pos, anchor, **kwargs)
 
     @classmethod
-    def ellipse(self, width, height, color, pos=POS_TOPLEFT,
+    def Ellipse(self, width, height, color, pos=POS_TOPLEFT,
                 anchor=ANCHOR_CENTER, **kwargs):
         """Creates an actor with an ellipse as an image."""
         name = self._make_shape_image("__SHAPE_ELLIPSE__", width, height,
@@ -283,7 +283,7 @@ class Actor:
         return Actor(name, pos, anchor, **kwargs)
 
     @classmethod
-    def triangle(self, width, height, color, pos=POS_TOPLEFT,
+    def Triangle(self, width, height, color, pos=POS_TOPLEFT,
                  anchor=ANCHOR_CENTER, **kwargs):
         """Creates an actor with a triangle as an image."""
         name = self._make_shape_image("__SHAPE_TRIANGLE__", width, height,

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -4,6 +4,7 @@ import pygame
 
 from pgzero.actor import calculate_anchor, Actor
 from pgzero.loaders import set_root
+from pgzero.loaders import images
 
 
 TEST_MODULE = "pgzero.actor"
@@ -146,3 +147,78 @@ class ActorTest(unittest.TestCase):
         a = Actor("alien")
         for attribute in dir(a):
             a.__getattr__(attribute)
+
+    def test_actor_square(self):
+        """The square image is created correctly and the result is a valid
+        actor."""
+        square = Actor.square(10, "red")
+        name = "__SHAPE_SQUARE__10x10_red"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 10)
+        self.assertEqual(height, 10)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (255, 0, 0, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_rectangle(self):
+        """The rectangle image is created correctly and the result is a valid
+        actor."""
+        square = Actor.rectangle(10, 5, "green")
+        name = "__SHAPE_RECTANGLE__10x5_green"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 10)
+        self.assertEqual(height, 5)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (0, 255, 0, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_circle(self):
+        """The circular image is created correctly and the result is a valid
+        actor."""
+        square = Actor.circle(5, "blue")
+        name = "__SHAPE_CIRCLE__5x5_blue"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 5)
+        self.assertEqual(height, 5)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (0, 0, 255, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_ellipse(self):
+        """The elliptical image is created correctly and the result is a valid
+        actor."""
+        square = Actor.ellipse(5, 10, "yellow")
+        name = "__SHAPE_ELLIPSE__5x10_yellow"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 5)
+        self.assertEqual(height, 10)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (255, 255, 0, 255)
+        )
+        self.assertEqual(type(square), Actor)
+
+    def test_actor_triangle(self):
+        """The triangular image is created correctly and the result is a valid
+        actor."""
+        square = Actor.triangle(15, 15, "fuchsia")
+        name = "__SHAPE_TRIANGLE__15x15_fuchsia"
+        self.assertIn((name, (), ()), images._cache)
+        surf = images.load(name)
+        width, height = surf.get_size()
+        self.assertEqual(width, 15)
+        self.assertEqual(height, 15)
+        self.assertEqual(
+            surf.get_at((width//2, height//2)), (255, 0, 255, 255)
+        )
+        self.assertEqual(type(square), Actor)

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -151,8 +151,8 @@ class ActorTest(unittest.TestCase):
     def test_actor_square(self):
         """The square image is created correctly and the result is a valid
         actor."""
-        square = Actor.Square(10, "red")
-        name = "__SHAPE_SQUARE__10x10_red"
+        square = Actor.Rectangle(10, 10, "red")
+        name = "__SHAPE_RECTANGLE__10x10_red"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)
         width, height = surf.get_size()
@@ -181,8 +181,8 @@ class ActorTest(unittest.TestCase):
     def test_actor_circle(self):
         """The circular image is created correctly and the result is a valid
         actor."""
-        square = Actor.Circle(5, "blue")
-        name = "__SHAPE_CIRCLE__5x5_blue"
+        square = Actor.Ellipse(5, 5, "blue")
+        name = "__SHAPE_ELLIPSE__5x5_blue"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)
         width, height = surf.get_size()

--- a/test/test_actor.py
+++ b/test/test_actor.py
@@ -151,7 +151,7 @@ class ActorTest(unittest.TestCase):
     def test_actor_square(self):
         """The square image is created correctly and the result is a valid
         actor."""
-        square = Actor.square(10, "red")
+        square = Actor.Square(10, "red")
         name = "__SHAPE_SQUARE__10x10_red"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)
@@ -166,7 +166,7 @@ class ActorTest(unittest.TestCase):
     def test_actor_rectangle(self):
         """The rectangle image is created correctly and the result is a valid
         actor."""
-        square = Actor.rectangle(10, 5, "green")
+        square = Actor.Rectangle(10, 5, "green")
         name = "__SHAPE_RECTANGLE__10x5_green"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)
@@ -181,7 +181,7 @@ class ActorTest(unittest.TestCase):
     def test_actor_circle(self):
         """The circular image is created correctly and the result is a valid
         actor."""
-        square = Actor.circle(5, "blue")
+        square = Actor.Circle(5, "blue")
         name = "__SHAPE_CIRCLE__5x5_blue"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)
@@ -196,7 +196,7 @@ class ActorTest(unittest.TestCase):
     def test_actor_ellipse(self):
         """The elliptical image is created correctly and the result is a valid
         actor."""
-        square = Actor.ellipse(5, 10, "yellow")
+        square = Actor.Ellipse(5, 10, "yellow")
         name = "__SHAPE_ELLIPSE__5x10_yellow"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)
@@ -211,7 +211,7 @@ class ActorTest(unittest.TestCase):
     def test_actor_triangle(self):
         """The triangular image is created correctly and the result is a valid
         actor."""
-        square = Actor.triangle(15, 15, "fuchsia")
+        square = Actor.Triangle(15, 15, "fuchsia")
         name = "__SHAPE_TRIANGLE__15x15_fuchsia"
         self.assertIn((name, (), ()), images._cache)
         surf = images.load(name)


### PR DESCRIPTION
Fixes #235

This PR introduces classmethods to Actor to create actors from simple filled shapes with a given color.

Available functions:
- `Actor.Square(side, color)`
- `Actor.Rectangle(width, height, color)`
- `Actor.Circle(diameter, color)`
- `Actor.Ellipse(width, height, color)`
- `Actor.Triangle(width, height, color)`

All keyword assignments as well as anchor and starting position as positional arguments remain available when using these functions, for example `player = Actor.Square(15, "blue", (40, 25))`

The actors are completely normal actors, the shapes are created as image surfaces and saved in the image cache so that creating many actors with the same shape, dimensions and color does not increase cost. This way, users can begin to implement features that rely on Actor functionality without having image files yet. Once they have an image file they want, as long as it has the same dimensions, they can swap to it simply by changing `Actor.Shape(dimensions, color)` to `Actor(image_string)`.

I am still thinking about whether `Square` and `Circle` should be removed, since the same results can easily be achieved via `Rectangle` and `Ellipse`. I am leaning towards doing so to lower the number of functions that are available, making it easier for beginners to keep an overview. I would like feedback on that before we merge anything though.

Documentation and tests have been added. 